### PR TITLE
Contact Form -- Home Page

### DIFF
--- a/assets/custom.scss.liquid
+++ b/assets/custom.scss.liquid
@@ -1,3 +1,10 @@
+// Colors
+$success-green: #4caf50;
+$white: #ffffff;
+
+// Breakpoints
+$theme-desktop: 990px;
+
 // Intro text [ Section ]
 .intro-text__content {
   max-width: 768px;
@@ -39,5 +46,35 @@
   .methodDescription,
   .store-content {
     display:  none !important;
+  }
+}
+
+// Dynamic Section [ Contact Form ]
+.contact-form-section {
+  padding-top: 2.5em;
+}
+
+// Form messsages
+.form-success {
+  background: $success-green;
+  color: $white;
+  padding: 1em;
+}
+
+.errors {
+  padding: 1em;
+}
+
+.grid--one-element {
+  margin: 0;
+}
+
+.grid__item--single-form {
+  padding-left: 0;
+  width: 100%;
+
+  form {
+    margin: 0 auto;
+    max-width: 800px;
   }
 }

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -1,0 +1,103 @@
+{% assign only_form = false %}
+
+{% if section.settings.contact_heading == blank and section.settings.contact_form_richtext == blank %}
+  {% assign only_form = true %}
+{% endif %}
+
+
+<div class="lg--up--seven-eighths mx--auto px2">
+  <div class="grid {% if only_form %} grid--one-element {% endif %}">
+    {% unless only_form %}
+      <div class="grid__item lg--up--two-fifths">
+        {% if section.settings.contact_heading != blank %}
+          <h1 class="f--heading font-size__heading m0">{{ section.settings.contact_heading }}</h1>
+        {% endif %}
+        {% if section.settings.contact_form_richtext != blank %}
+          <div class="rte mt2  font-size__basic">
+            {{ section.settings.contact_form_richtext }}
+          </div>
+        {% endif %}
+      </div>
+    {% endunless %}
+    <div class="grid__item lg--up--three-fifths lg--up--mt0 {% if only_form %} grid__item--single-form {% endif %}">
+
+      {% form 'contact' %}
+
+        {% if form.posted_successfully? %}
+          <p class="form-success">
+            {{ 'contact.form.post_success' | t }}
+          </p>
+        {% endif %} 
+
+        {{ form.errors | default_errors }}
+
+        <label class="mt2 block" for="ContactFormName">{{ 'contact.form.name' | t }}</label>
+        <input type="text"
+          class="block mt1 full--w px2 py1 bg--transparent border--{{ section_color }}-text"
+          name="contact[name]"
+          id="ContactFormName"
+          placeholder="{{ 'contact.form.name' | t }}"
+          value="{% if form[name] %}{{ form[name] }}{% elsif customer %}{{ customer.name }}{% endif %}">
+
+        <label class="mt2 block" for="ContactFormEmail">{{ 'contact.form.email' | t }}</label>
+        <input type="email"
+          class="block mt1 full--w  px2 py1 bg--transparent border--{{ section_color }}-text"
+          name="contact[email]"
+          id="ContactFormEmail"
+          placeholder="{{ 'contact.form.email' | t }}"
+          value="{% if form.email %}{{ form.email }}{% elsif customer %}{{ customer.email }}{% endif %}"
+          spellcheck="false"
+          autocomplete="off"
+          autocapitalize="off">
+
+        <label class="mt2 block" for="ContactFormPhone">{{ 'contact.form.phone' | t }}</label>
+        <input type="tel"
+          class="block mt1 full--w px2 py1 bg--transparent border--{{ section_color }}-text"
+          name="contact[phone]"
+          id="ContactFormPhone"
+          placeholder="{{ 'contact.form.phone' | t }}"
+          value="{% if form[phone] %}{{ form[phone] }}{% elsif customer %}{{ customer.phone }}{% endif %}"
+          pattern="[0-9\-]*">
+
+        <label class="mt2 block" for="ContactFormMessage">{{ 'contact.form.message' | t }}</label>
+        <textarea rows="10"
+          class="block mt1 full--w  px2 py1 bg--transparent border--{{ section_color }}-text"
+          name="contact[body]"
+          id="ContactFormMessage"
+          placeholder="{{ 'contact.form.message' | t }}">{%- if form.body -%}{{ form.body }}{%- endif -%}</textarea>
+
+        <input type="submit" class="block full--w max-width--1 btn border--none mt3 px2 py1 bg--{{ section_color }}-text color--{{ section_color }}-text--overlay hover-bg--{{ section_color }}" value="{{ 'contact.form.send' | t }}">
+
+      {% endform %}
+
+    </div>
+  </div>
+</div>
+
+
+{% schema %}
+{
+  "name": "Contact Form",
+  "class": "contact-form-section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "contact_heading",
+      "label": "Heading",
+      "default": "Contact Form"
+    },
+    {
+      "type": "richtext",
+      "id": "contact_form_richtext",
+      "label": "Text",
+      "default": "<p>Contact <b>Lorem Ipsum</b></p>"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Contact Form",
+      "category": "Form"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
# Description
Añadimos un nuevo dynamic section para poder mostrar un contact form del lado derecho y un header + rich text del lado izquierdo.
Reutilicé los estilos que ya existen para mostrar este form y texto. sólo modifiqué los espacios entre los elementos.

# Visual references
![image](https://user-images.githubusercontent.com/43417614/97270727-3cd5c100-17f5-11eb-85f1-18daabdc3ef5.png)
Success Message
![chrome_j76QgyMuxT](https://user-images.githubusercontent.com/43417614/97270764-495a1980-17f5-11eb-85e8-b44db528acfa.png)
El mensaje de error lo dejé tal como lo tiene el template, sólo le añadí un poco más de padding. No encontré la forma de testear el error en el contact form, pero lo probé en el login. Te enseño cómo se vería:
![chrome_mHCGy8Gzsy](https://user-images.githubusercontent.com/43417614/97270860-6b539c00-17f5-11eb-8c60-35ff3fbb9323.png)

En caso de no tener nada en heading ni en el richtext el form se posiciona en el centro de la pantalla:
![gqgCyxh9MM](https://user-images.githubusercontent.com/43417614/97271255-f339a600-17f5-11eb-9014-128e0b818a1e.gif)

Está llegando bien la información al correo:
![image](https://user-images.githubusercontent.com/43417614/97271380-195f4600-17f6-11eb-803d-b9a1ab2fedf9.png)

Restablecí los correos originales:
![image](https://user-images.githubusercontent.com/43417614/97271314-05b3df80-17f6-11eb-9fb1-e2236e1d7229.png)

# Links
Task: https://trello.com/c/CoK5YzRJ/10-formulario-de-contacto-en-homepage
Theme [Cascade [Develop]](https://aracataca.mx/?_ab=0&_fd=0&_sc=1&preview_theme_id=100418420781)